### PR TITLE
Add `--no-cache` to `docker build` instruction

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ help: ## Prints this help.
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-10s\033[0m %s\n", $$1, $$2}'
 
 build: ## Builds browserstack-local
-	docker build -t quay.io/typeform/browserstack-local:${VERSION} .
+	docker build --no-cache -t quay.io/typeform/browserstack-local:${VERSION} .
 	docker tag quay.io/typeform/browserstack-local:${VERSION} quay.io/typeform/browserstack-local:latest
 
 push:  ## Pushes browserstack-local


### PR DESCRIPTION
This is so that the latest version of the BrowserStack Local binary is downloaded.